### PR TITLE
docs: links for types, manifest keywords and categories, docsrs flag for tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,26 @@ description = "A singleton. Maybe."
 readme = "README.md"
 homepage = "https://github.com/ufoscout/maybe-once"
 repository = "https://github.com/ufoscout/maybe-once"
+include = ["examples/**/*", "src/**/*", "README.md", "LICENSE"]
+documentation = "https://docs.rs/maybe-once/"
+rust-version = "1.78.0"
+categories = ["asynchronous", "concurrency"]
+keywords = ["singleton", "lazy", "once", "thread-safe", "async", "tokio"]
 
 [workspace]
-members = [
-    "examples/*",
-]
+members = ["examples/*"]
 
 [package.metadata.docs.rs]
 # Generate docs for all features
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 log = "0.4"
 parking_lot = "0.12"
-tokio = { version = "1", default-features = false, features = ["sync"], optional = true}
+tokio = { version = "1", default-features = false, features = [
+    "sync",
+], optional = true }
 
 [dev-dependencies]
 rand = "0.9"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # maybe-once
 
-![crates.io](https://img.shields.io/crates/v/maybe-once.svg)
+[![crates.io](https://img.shields.io/crates/v/maybe-once.svg)](https://crates.io/crates/maybe-once)
+[![docs.rs](https://docs.rs/maybe-once/badge.svg)](https://docs.rs/maybe-once)
 ![Build Status](https://github.com/ufoscout/maybe-once/actions/workflows/build_and_test.yml/badge.svg)
 [![codecov](https://codecov.io/gh/ufoscout/maybe-once/branch/master/graph/badge.svg)](https://codecov.io/gh/ufoscout/maybe-once)
 
-# What is this?
+## What is this?
 
 `maybe-once` offers a variation of `OnceLock` that keeps track of the number of references to the internal data
 and drops it every time the references counter goes to 0.
 
-# Why is this useful?
+## Why is this useful?
 
 In Rust static variables are not dropped when the program terminates. This is a problem when you need to initialize a shared resource that must be dropped when it is no longer used or when the process terminates. This happens, for example, when you a have a common resource to be used by a set of integration tests, and you want it to be dropped when the tests terminates.
 
 Check the examples to see how to use it with docker and [testcontainers](https://github.com/testcontainers/testcontainers-rs).
 
-# Usage examples    
+## Usage examples
 
 ```rust
 mod test {
@@ -80,7 +81,7 @@ mod test {
 }
 ```
 
-# Usage with tokio
+## Usage with tokio
 
 The `tokio` feature of this crate allows you to use the optional `MaybeOnceAsync` object to initialize a shared resource using an async function.
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -3,7 +3,7 @@ use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::ops::Deref;
 use std::sync::Arc;
 
-/// A `MaybeOnce` object is a variation of the `OnceLock` object that keeps track of the number of references to the internal data
+/// A [`MaybeOnce`] object is a variation of the [`std::sync::OnceLock`] object that keeps track of the number of references to the internal data
 /// and drops it every time the references counter goes to 0. When the data is accessed,
 /// it will be created if it does not exist, or it will recreated if it was previously dropped.
 ///
@@ -72,12 +72,12 @@ pub struct MaybeOnce<T> {
 }
 
 impl<T> MaybeOnce<T> {
-    /// Creates a new `MaybeOnce` object with the given `init` function.
+    /// Creates a new [`MaybeOnce`] object with the given `init` function.
     ///
     /// `init` is a function that creates a new `T` object. It is lazily called the first time
     /// `data` is called and every time after the data is dropped.
     ///
-    /// The returned `MaybeOnce` object is then used to access the shared data with the
+    /// The returned [`MaybeOnce`] object is then used to access the shared data with the
     /// `data` method.
     pub fn new(init: fn() -> T) -> Self {
         MaybeOnce {
@@ -88,7 +88,7 @@ impl<T> MaybeOnce<T> {
         }
     }
 
-    /// This function returns a `Data` object, which allows you to access the shared data.
+    /// This function returns a [`Data`] object, which allows you to access the shared data.
     ///
     /// The `serial` parameter allows you to control whether the data is accessed in a serial
     /// or parallel manner. If `serial` is `true`, the data will be accessed in a serial manner,
@@ -96,9 +96,9 @@ impl<T> MaybeOnce<T> {
     /// If `serial` is `false`, the data will be accessed in a parallel manner, meaning that
     /// any number of threads can access the data at the same time.
     ///
-    /// The returned `Data` object implements `Deref` and `AsRef`, so you can use it like a reference.
+    /// The returned [`Data`] object implements [`Deref`] and [`AsRef`], so you can use it like a reference.
     ///
-    /// The `Data` object also implements `Drop`, so when it goes out of scope, the lock is released.
+    /// The [`Data`] object also implements [`Drop`], so when it goes out of scope, the lock is released.
     pub fn data(&self, serial: bool) -> Data<'_, T> {
         {
             let mut lock = self.callers.lock();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@
 pub mod blocking;
 
 #[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod tokio;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -7,7 +7,7 @@ use parking_lot::{Mutex, RwLock};
 use std::future::Future;
 use tokio::sync::{RwLock as AsyncRwLock, RwLockReadGuard, RwLockWriteGuard};
 
-/// A `MaybeOnce` object is a variation of the `OnceLock` object that keeps track of the number of references to the internal data
+/// A [`MaybeOnceAsync`] object is a variation of the [`std::sync::OnceLock`] object that keeps track of the number of references to the internal data
 /// and drops it every time the references counter goes to 0. When the data is accessed,
 /// it will be created if it does not exist, or it will recreated if it was previously dropped.
 ///
@@ -78,12 +78,12 @@ pub struct MaybeOnceAsync<T> {
 }
 
 impl<T> MaybeOnceAsync<T> {
-    /// Creates a new `MaybeOnceAsync` object with the given `init` function.
+    /// Creates a new [`MaybeOnceAsync`] object with the given `init` function.
     ///
     /// `init` is a function that creates a new `T` object. It is lazily called the first time
     /// `data` is called and every time after the data is dropped.
     ///
-    /// The returned `MaybeOnceAsync` object is then used to access the shared data with the
+    /// The returned [`MaybeOnceAsync`] object is then used to access the shared data with the
     /// `data` method.
     pub fn new(init: fn() -> Pin<Box<dyn Send + Future<Output = T>>>) -> Self {
         MaybeOnceAsync {
@@ -94,17 +94,17 @@ impl<T> MaybeOnceAsync<T> {
         }
     }
 
-    /// This function returns a `Data` object, which allows you to access the shared data.
+    /// This function returns a [`Data`] object, which allows you to access the shared data.
     ///
     /// The `serial` parameter allows you to control whether the data is accessed in a serial
     /// or parallel manner. If `serial` is `true`, the data will be accessed in a serial manner,
-    /// meaning that no other thread can access the data until the returned `Data` is dropped.
+    /// meaning that no other thread can access the data until the returned [`Data`] is dropped.
     /// If `serial` is `false`, the data will be accessed in a parallel manner, meaning that
     /// any number of threads can access the data at the same time.
     ///
-    /// The returned `Data` object implements `Deref` and `AsRef`, so you can use it like a reference.
+    /// The returned [`Data`] object implements [`Deref`] and [`AsRef`], so you can use it like a reference.
     ///
-    /// The `Data` object also implements `Drop`, so when it goes out of scope, the lock is released.
+    /// The [`Data`] object also implements [`Drop`], so when it goes out of scope, the lock is released.
     pub async fn data(&self, serial: bool) -> Data<'_, T> {
         {
             let mut lock = self.callers.lock();


### PR DESCRIPTION
links for types in documentation; manifest keywords and categories; docsrs flag for tokio